### PR TITLE
Spec wording

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,3 +18,8 @@ namespace :db do
     File.delete(connection_details.fetch('database')) if File.exist?(connection_details.fetch('database'))
   end
 end
+
+desc "Drop into pry"
+task :console do
+  Pry.start
+end

--- a/app/models/show.rb
+++ b/app/models/show.rb
@@ -1,0 +1,31 @@
+class Show < ActiveRecord::Base
+
+  def self.highest_rating
+    self.maximum(:rating)
+  end
+
+  def self.most_popular_show
+    self.find_by(rating: self.highest_rating)
+  end
+
+  def self.lowest_rating
+    self.minimum(:rating)
+  end
+
+  def self.least_popular_show
+    self.find_by(rating: self.lowest_rating)
+  end
+
+  def self.ratings_sum
+    self.sum(:rating)
+  end
+
+  def self.popular_shows
+    self.where("rating > ?", 5)
+  end
+
+  def self.shows_by_alphabetical_order
+    self.order(:name)
+  end
+
+end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,6 +1,7 @@
 require "bundler/setup"
 require 'yaml'
 require 'active_record'
+require 'pry'
 
 Bundler.require
 

--- a/db/migrate/001_create_shows.rb
+++ b/db/migrate/001_create_shows.rb
@@ -1,0 +1,12 @@
+class CreateShows < ActiveRecord::Migration
+
+  def change
+    create_table :shows do |t|
+      t.string :name
+      t.string :network
+      t.string :day
+      t.integer :rating
+    end
+  end
+
+end

--- a/db/migrate/002_add_season_to_shows.rb
+++ b/db/migrate/002_add_season_to_shows.rb
@@ -1,0 +1,7 @@
+class AddSeasonToShows < ActiveRecord::Migration
+
+  def change
+    add_column :shows, :season, :string
+  end
+
+end

--- a/spec/show_spec.rb
+++ b/spec/show_spec.rb
@@ -35,7 +35,7 @@ describe Show do
   end
 
   describe "::highest_rating" do
-    it "returns the TV show with the highest rating" do
+    it "returns the rating value of the TV show with the highest rating" do
       expect(Show.highest_rating).to eq(10)
     end
   end
@@ -47,7 +47,7 @@ describe Show do
   end
 
   describe "::lowest_rating" do
-    it "returns the TV show with the lowest rating" do
+    it "returns the rating value of the TV show with the lowest rating" do
       expect(Show.lowest_rating).to eq(2)
     end
   end


### PR DESCRIPTION
Unless the wording of the description of these two tests is intentionally vague to require the student to read the test results and spec file, this test should clarify that its return should be the value of the :rating column and not the show object itself. 